### PR TITLE
Fixed OPCUA binding

### DIFF
--- a/examples/scripts/modbus-thing.jsonld
+++ b/examples/scripts/modbus-thing.jsonld
@@ -27,7 +27,8 @@
             "writeproperty"
           ],
           "modbus:function": 5,
-          "modbus:range": [0, 1],
+          "modbus:offset": 0,
+          "modbus:length": 1,
           "modbus:unitID": 1
         },
         {
@@ -37,7 +38,8 @@
             "readproperty"
           ],
           "modbus:function": 1,
-          "modbus:range": [0, 1],
+          "modbus:offset": 0,
+          "modbus:length": 1,
           "modbus:unitID": 1
         }
       ]
@@ -57,7 +59,7 @@
             "writeproperty"
           ],
           "modbus:function": 6,
-          "modbus:range": [8],
+          "modbus:offset": 8,
           "modbus:unitID": 1
         },
         {
@@ -67,7 +69,7 @@
             "readproperty"
           ],
           "modbus:function": 3,
-          "modbus:range": [8],
+          "modbus:offset": 8,
           "modbus:unitID": 1
         }
       ]

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci",
     "prebuild": "npm run bootstrap",
-    "build": "lerna --ignore @node-wot/binding-opcua run build",
+    "build": "lerna run build",
     "pretest": "npm run build",
     "start": "cd packages/cli && npm run start",
     "debug": "cd packages/cli && npm run debug",
-    "test": "lerna --ignore @node-wot/binding-opcua run test",
+    "test": "lerna run test",
     "prelink": "npm run unlock",
     "link": "lerna-run npm link",
     "codestyle": "lerna run codestyle",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/eclipse/thingweb.node-wot.git"
   },
   "devDependencies": {
+    "@types/mocha": "^8.2.2",
     "lerna": "^3.20.2",
     "lerna-run": "0.0.2",
     "rimraf": "3.0.2"
@@ -16,11 +17,11 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci",
     "prebuild": "npm run bootstrap",
-    "build": "lerna run build",
+    "build": "lerna --ignore @node-wot/binding-opcua run build",
     "pretest": "npm run build",
     "start": "cd packages/cli && npm run start",
     "debug": "cd packages/cli && npm run debug",
-    "test": "lerna run test",
+    "test": "lerna --ignore @node-wot/binding-opcua run test",
     "prelink": "npm run unlock",
     "link": "lerna-run npm link",
     "codestyle": "lerna run codestyle",

--- a/packages/binding-modbus/README.md
+++ b/packages/binding-modbus/README.md
@@ -77,7 +77,7 @@ with the following meaning:
 * `<host>` is the host name or IP address of the MODBUS slave
 * `<port>` is the optional TCP port number used to access the MODBUS slave. Default is 502
 * `<unitid>` is the MODBUS unit id of the MODBUS slave; same as [modbus:unitID](#modbus:unitID)  
-* `<offset>` is the starting offset register number; the first parameter of [modbus:offset](#modbus:offset)   
+* `<offset>` is the starting offset register number; see [modbus:offset](#modbus:offset)   
 * `<length>` is the optional number of registers to access. Default is 1; see [modbus:length](#modbus:length)
 
 When specified URL values override the corresponding `form` parameter.

--- a/packages/binding-modbus/README.md
+++ b/packages/binding-modbus/README.md
@@ -51,9 +51,12 @@ A more user-friendly property to specify `modbus:function`. It can be filled wit
 ### modbus:unitID
 The physical bus address of the unit targeted by the mobus request.
  
-### modbus:range
-This property defines how many registers or coils should be read or written. The value is a tuple where the first element is the starting address while the second represents the total amount of registers. For example in a reading command the tuple [2,3] indicate that the values of registers 2,3,4 should be returned as response.
- 
+### modbus:offset
+This property defines the starting address of registers or coils that are meant to be written.
+
+### modbus:length
+This property defines the total amount of registers or coils that should be written, beginning with the register specified with the property 'modbus:offset'.
+
 ### modbus:pollingTime
 The polling time used for subscriptions. The client will issue a reading command every modbus:pollingTime milliseconds. Note that the reading request timeout can be still controlled using modbus:timeout property. 
 
@@ -74,8 +77,8 @@ with the following meaning:
 * `<host>` is the host name or IP address of the MODBUS slave
 * `<port>` is the optional TCP port number used to access the MODBUS slave. Default is 502
 * `<unitid>` is the MODBUS unit id of the MODBUS slave; same as [modbus:unitID](#modbus:unitID)  
-* `<offset>` is the starting offset register number; the first parameter of [modbus:range](#modbus:range)   
-* `<length>` is the optional number of registers to access. Default is 1; see [modbus:range](#modbus:range)
+* `<offset>` is the starting offset register number; the first parameter of [modbus:offset](#modbus:offset)   
+* `<length>` is the optional number of registers to access. Default is 1; see [modbus:length](#modbus:length)
 
 When specified URL values override the corresponding `form` parameter.
  
@@ -134,7 +137,7 @@ Reads the 8th input register of the unit 1
         "readproperty"
     ],
     "modbus:function": "readInputRegister",
-    "modbus:range": [8],
+    "modbus:offset": 8,
     "modbus:unitID": 1,
     "modbus:timeout": 2000
 }
@@ -150,7 +153,7 @@ Read and write the 8th holding register of the unit 1
         "writeproperty"
     ],
     "modbus:entity": "HoldingRegister",
-    "modbus:range": [8],
+    "modbus:offset": 8,
     "modbus:unitID": 1
 }
 ```
@@ -164,7 +167,7 @@ Polls the 8th holding register of the unit 1 every second.
         "observeproperty"
     ],
     "modbus:entity": "HoldingRegister",
-    "modbus:range": [8],
+    "modbus:offset": 8,
     "modbus:unitID": 1,
     "modbus:pollingTime: 1000
 }

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -177,8 +177,8 @@ export default class ModbusClient implements ProtocolClient {
     }
 
 
-    if(!form['modbus:offset']) {
-        result['modbus:offset'] = 0;
+    if(form['modbus:offset'] !== 0) {
+        throw new Error('Malformed form: offset must be defined');
     }
     
     if(!form['modbus:length'] && contentLength === 0) {

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -40,7 +40,7 @@ export default class ModbusClient implements ProtocolClient {
   }
   unlinkResource(form: ModbusForm): Promise<void> {
     form = this.validateAndFillDefaultForm(form, 0)
-    const id = `${form.href}/${form['modbus:unitID']}#${form['modbus:function']}?${form['modbus:range'][0]}&${form['modbus:range'][1]}`
+    const id = `${form.href}/${form['modbus:unitID']}#${form['modbus:function']}?${form['modbus:offset']}&${form['modbus:length']}`
 
 
     this._subscriptions.get(id).unsubscribe()
@@ -52,7 +52,7 @@ export default class ModbusClient implements ProtocolClient {
     next: ((value: any) => void), error?: (error: any) => void, complete?: () => void): any {
     form = this.validateAndFillDefaultForm(form, 0)
 
-    const id = `${form.href}/${form['modbus:unitID']}#${form['modbus:function']}?${form['modbus:range'][0]}&${form['modbus:range'][1]}`
+    const id = `${form.href}/${form['modbus:unitID']}#${form['modbus:function']}?${form['modbus:offset']}&${form['modbus:length']}`
 
     if (this._subscriptions.has(id)) {
       throw new Error('Already subscribed for ' + id + '. Multiple subscriptions are not supported');
@@ -116,14 +116,14 @@ export default class ModbusClient implements ProtocolClient {
     let query = parsed.searchParams
 
     input['modbus:unitID'] = parseInt(pathComp[1], 10) || input['modbus:unitID'];
-    input['modbus:range'][0] = parseInt(query.get('offset'), 10) || input['modbus:range'][0];
-    input['modbus:range'][1] = parseInt(query.get('length'), 10) || input['modbus:range'][1];
+    input['modbus:offset'] = parseInt(query.get('offset'), 10) || input['modbus:offset'];
+    input['modbus:length'] = parseInt(query.get('length'), 10) || input['modbus:length'];
   }
 
   private validateContentLength(form: ModbusForm, content: Content) {
 
     const mpy = form['modbus:entity'] === 'InputRegister' || form['modbus:entity'] === 'HoldingRegister' ? 2 : 1;
-    const length = form['modbus:range'][1]
+    const length = form['modbus:length']
     if (content && content.body.length !== mpy * length) {
       throw new Error('Content length does not match register / coil count, got ' + content.body.length + ' bytes for '
         + length + ` ${mpy === 2 ? 'registers' : 'coils'}`);
@@ -176,15 +176,17 @@ export default class ModbusClient implements ProtocolClient {
       result['modbus:entity'] = modbusFunctionToEntity(result['modbus:function'] as ModbusFunction)
     }
 
-    // fill default range
-    if (!form['modbus:range']) {
-      result['modbus:range'] = [0, 1]
-    } else if (!form['modbus:range'][1] && contentLength === 0) {
-      result['modbus:range'] = [form['modbus:range'][0], 1]
-    } else if (!form['modbus:range'][1] && contentLength > 0) {
-      const regSize = result['modbus:entity'] === 'InputRegister' ||
-        result['modbus:entity'] === 'HoldingRegister' ? 2 : 1;
-      result['modbus:range'] = [form['modbus:range'][0], contentLength / regSize]
+
+    if(!form['modbus:offset']) {
+        result['modbus:offset'] = 0;
+    }
+    
+    if(!form['modbus:length'] && contentLength === 0) {
+        result['modbus:length'] = 1;
+    } else if(!form['modbus:length'] && contentLength > 0) {
+        const regSize = result['modbus:entity'] === 'InputRegister' ||
+               result['modbus:entity'] === 'HoldingRegister' ? 2 : 1;
+        result['modbus:length'] = contentLength / regSize;
     }
 
     result['modbus:pollingTime'] = form['modbus:pollingTime'] ? form['modbus:pollingTime'] : DEFAULT_POLLING

--- a/packages/binding-modbus/src/modbus-connection.ts
+++ b/packages/binding-modbus/src/modbus-connection.ts
@@ -359,8 +359,8 @@ export class PropertyOperation {
   constructor(form: ModbusForm, content?: Buffer) {
     this.unitId = form['modbus:unitID'];
     this.registerType = form['modbus:entity'];
-    this.base = form['modbus:range'][0];
-    this.length = form['modbus:range'][1];
+    this.base = form['modbus:offset'];
+    this.length = form['modbus:length'];
     this.function = form['modbus:function'] as ModbusFunction;
     this.content = content;
     this.transaction = null;

--- a/packages/binding-modbus/src/modbus.ts
+++ b/packages/binding-modbus/src/modbus.ts
@@ -22,12 +22,16 @@ export class ModbusForm extends Form {
    */
   public 'modbus:unitID': number;
   /**
-   * Defines how many registers or coils should be written. The first
-   * element of the tuple is the starting address while the second is 
-   * the total amount of registers. For example [2,3] means that registers
-   * 2,3,4 will be returned as response.
+   * Defines the starting address of registers or coils that are
+   * meant to be written.
    */
-  public 'modbus:range'?: [number, number?];
+  public 'modbus:offset'?: number;
+  /**
+   * Defines the total amount of registers or coils that 
+   * should be written, beginning with the register specified
+   * with the property 'modbus:offset'.
+   */
+  public 'modbus:length'?: number;
   /**
    * Timeout in milliseconds of the modbus request. Default to 1000 milliseconds
    */

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -263,6 +263,19 @@ describe('Modbus client test', () => {
 
             return promise.should.eventually.rejectedWith("Undefined function number or name: 255")
         });
+
+        it('should throw exception for missing offset', () => {
+
+            const form: ModbusForm = {
+                href: "modbus://127.0.0.1:8502",
+                "modbus:function": 1,
+                "modbus:unitID": 1
+            }
+
+            const promise = client.readResource(form)
+
+            return promise.should.eventually.rejectedWith("Malformed form: offset must be defined")
+        });
     });
 
     describe('write resource', () => {

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -36,7 +36,8 @@ describe('Modbus client test', () => {
         const form: ModbusForm = {
             href: "modbus://127.0.0.1:8502",
             "modbus:entity": "Coil",
-            "modbus:range": [0, 1],
+            "modbus:offset": 0,
+            "modbus:length": 1,
             "modbus:unitID": 1
         }
 
@@ -50,7 +51,8 @@ describe('Modbus client test', () => {
         const form: ModbusForm = {
             href: "modbus://127.0.0.1:8502",
             "modbus:entity": "HoldingRegister",
-            "modbus:range": [0, 1],
+            "modbus:offset": 0,
+            "modbus:length": 1,
             "modbus:unitID": 1
         }
 
@@ -63,7 +65,8 @@ describe('Modbus client test', () => {
         const form: ModbusForm = {
             href: "modbus://127.0.0.1:8502",
             "modbus:entity": "DiscreteInput",
-            "modbus:range": [0, 1],
+            "modbus:offset": 0,
+            "modbus:length": 1,
             "modbus:unitID": 1
         }
 
@@ -76,7 +79,8 @@ describe('Modbus client test', () => {
         const form: ModbusForm = {
             href: "modbus://127.0.0.1:8502",
             "modbus:function": "readCoil",
-            "modbus:range": [0, 1],
+            "modbus:offset": 0,
+            "modbus:length": 1,
             "modbus:unitID": 1
         }
 
@@ -87,14 +91,15 @@ describe('Modbus client test', () => {
         const form: ModbusForm = {
             href: "modbus://127.0.0.1:8502/2?offset=2&length=5",
             "modbus:function": "readCoil",
-            "modbus:range": [0, 1],
+            "modbus:offset": 0,
+            "modbus:length": 1,
             "modbus:unitID": 1
         }
 
         client["overrideFormFromURLPath"](form)
         form["modbus:unitID"].should.be.equal(2, "Form value not overridden")
-        form["modbus:range"][0].should.be.equal(2, "Form value not overridden")
-        form["modbus:range"][1].should.be.equal(5, "Form value not overridden")
+        form["modbus:offset"].should.be.equal(2, "Form value not overridden")
+        form["modbus:length"].should.be.equal(5, "Form value not overridden")
     });
 
     describe('misc', () => {
@@ -104,7 +109,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 1,
-                "modbus:range": [0, 1],
+                "modbus:offset": 0,
+                "modbus:length": 1,
                 "modbus:unitID": 1
             }
 
@@ -122,7 +128,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 1,
-                "modbus:range": [0, 1],
+                "modbus:offset": 0,
+                "modbus:length": 1,
                 "modbus:unitID": 1
             }
 
@@ -137,7 +144,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 1,
-                "modbus:range": [0, 3],
+                "modbus:offset": 0,
+                "modbus:length": 3,
                 "modbus:unitID": 1
             }
 
@@ -152,7 +160,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 2,
-                "modbus:range": [0, 1],
+                "modbus:offset": 0,
+                "modbus:length": 1,
                 "modbus:unitID": 1
             }
 
@@ -167,7 +176,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 2,
-                "modbus:range": [0, 3],
+                "modbus:offset": 0,
+                "modbus:length": 3,
                 "modbus:unitID": 1
             }
 
@@ -182,7 +192,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 3,
-                "modbus:range": [0, 1],
+                "modbus:offset": 0,
+                "modbus:length": 1,
                 "modbus:unitID": 1
             }
 
@@ -197,7 +208,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 3,
-                "modbus:range": [0, 3],
+                "modbus:offset": 0,
+                "modbus:length": 3,
                 "modbus:unitID": 1
             }
 
@@ -212,7 +224,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 4,
-                "modbus:range": [0, 1],
+                "modbus:offset": 0,
+                "modbus:length": 1,
                 "modbus:unitID": 1
             }
 
@@ -227,7 +240,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 4,
-                "modbus:range": [0, 3],
+                "modbus:offset": 0,
+                "modbus:length": 3,
                 "modbus:unitID": 1
             }
 
@@ -240,7 +254,8 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 255,
-                "modbus:range": [0, 3],
+                "modbus:offset": 0,
+                "modbus:length": 3,
                 "modbus:unitID": 1
             }
 
@@ -256,7 +271,7 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 5,
-                "modbus:range": [0],
+                "modbus:offset": 0,
                 "modbus:unitID": 1
             }
 
@@ -268,7 +283,7 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 15,
-                "modbus:range": [0],
+                "modbus:offset": 0,
                 "modbus:unitID": 1
             }
 
@@ -281,7 +296,7 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 6,
-                "modbus:range": [0],
+                "modbus:offset": 0,
                 "modbus:unitID": 1
             }
 
@@ -294,7 +309,7 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 16,
-                "modbus:range": [0],
+                "modbus:offset": 0,
                 "modbus:unitID": 1
             }
 
@@ -309,7 +324,7 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 1,
-                "modbus:range": [0],
+                "modbus:offset": 0,
                 "modbus:unitID": 1,
                 "modbus:pollingTime": 250
             }
@@ -326,7 +341,7 @@ describe('Modbus client test', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.1:8502",
                 "modbus:function": 1,
-                "modbus:range": [0],
+                "modbus:offset": 0,
                 "modbus:unitID": 1,
                 "modbus:pollingTime": 125
             }

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -39,7 +39,8 @@ describe('Modbus connection', () => {
             const form: ModbusForm = {
                 href: "modbus://127.0.0.2:8502",
                 "modbus:function": 15,
-                "modbus:range": [0,1],
+                "modbus:offset": 0,
+                "modbus:length": 1,
                 "modbus:unitID": 1
             }
             const connection = new ModbusConnection("127.0.0.2", 8503, {connectionTimeout: 200, connectionRetryTime: 10, maxRetries: 1 })

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -31,7 +31,7 @@
     "@node-wot/core": "0.7.3",
     "@types/url-parse": "^1.4.3",
     "case-1.5.3": "npm:case@^1.5.3",
-    "node-opcua-client": "^2.1.8",
+    "node-opcua-client": "^2.4.3",
     "typescript": "3.6.3",
     "url-parse": "^1.4.7",
     "wot-typescript-definitions": "0.7.3",

--- a/packages/binding-opcua/src/opcua-client.ts
+++ b/packages/binding-opcua/src/opcua-client.ts
@@ -29,7 +29,7 @@ import {
 	ClientSubscription,
 	TimestampsToReturn,
 	MonitoringParametersOptions,
-	ReadValueIdLike,
+	ReadValueIdOptions,
 	ClientMonitoredItem,
 	DataType,
 	DataValue,
@@ -59,7 +59,7 @@ export default class OpcuaClient implements ProtocolClient {
 				maxRetry: 1
 			},
 			requestedSessionTimeout: 10000,
-			endpoint_must_exist: false
+			endpointMustExist: false
 		}
 		if (_config) {
 			this.config = _config;
@@ -323,7 +323,7 @@ export default class OpcuaClient implements ProtocolClient {
 					subscription = ClientSubscription.create(self.session, defaultSubscriptionOptions);
 				}
 
-				const itemToMonitor: ReadValueIdLike = {
+				const itemToMonitor: ReadValueIdOptions = {
 					nodeId: nodeId,
 					attributeId: AttributeIds.Value
 				};


### PR DESCRIPTION
Broken build due to a problem in OPCUA binding is now fixed based on the suggestion found [here](https://github.com/node-opcua/node-opcua/issues/989).

Bonus point: `node-opcua-client` and `node-opcua-server` versions have been aligned.

TODO: run OPCUA binding tests. I'm not able to bring up a mock OPCUA server.