### PR TITLE
[core/consumed-thing] Usage of InteractionInput

### DIFF
--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -14,7 +14,7 @@ import { DataSchemaValue, InteractionInput } from 'wot-typescript-definitions';
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { ConsumedThing as IConsumedThing } from "wot-typescript-definitions";
+import {ConsumedThing as IConsumedThing} from "wot-typescript-definitions";
 
 import * as TD from "@node-wot/td-tools";
 
@@ -29,9 +29,6 @@ import { Subscribable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import UriTemplate = require('uritemplate');
 import { InteractionOutput } from "./interaction-output";
-import { Readable } from "stream";
-import ProtocolHelpers from "./protocol-helpers";
-import { ReadableStream } from 'web-streams-polyfill/ponyfill/es2018';
 
 enum Affordance {
     PropertyAffordance,
@@ -71,7 +68,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         // Deep clone the Thing Model 
         // without functions or methods
         let clonedModel = JSON.parse(JSON.stringify(thingModel))
-        Object.assign(this, clonedModel);
+        Object.assign(this,clonedModel);
         this.extendInteractions();
     }
 
@@ -80,7 +77,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     }
 
     public emitEvent(name: string, data: any): void {
-        console.warn("[core/consumed-thing]", "not implemented");
+        console.warn("[core/consumed-thing]","not implemented");
     }
 
     extendInteractions(): void {
@@ -135,7 +132,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     ensureClientSecurity(client: ProtocolClient) {
         // td-tools parser ensures this.security is an array
         if (this.security && this.securityDefinitions && Array.isArray(this.security) && this.security.length > 0) {
-            console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' setting credentials for ${client}`);
+            console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' setting credentials for ${client}`);
             let scs: Array<TD.SecurityScheme> = [];
             for (let s of this.security) {
                 let ws = this.securityDefinitions[s + ""]; // String vs. string (fix wot-typescript-definitions?)
@@ -159,14 +156,14 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
         if (options && options.formIndex) {
             // pick provided formIndex (if possible)
-            console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' asked to use formIndex '${options.formIndex}'`);
+            console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' asked to use formIndex '${options.formIndex}'`);
 
             if (options.formIndex >= 0 && options.formIndex < forms.length) {
                 form = forms[options.formIndex];
                 let scheme = Helpers.extractScheme(form.href);
 
                 if (this.getServient().hasClientFor(scheme)) {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' got client for '${scheme}'`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' got client for '${scheme}'`);
                     client = this.getServient().getClientFor(scheme);
 
                     if (!this.getClients().get(scheme)) {
@@ -186,18 +183,18 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
             if (cacheIdx !== -1) {
                 // from cache
-                console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`);
+                console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`);
                 client = this.getClients().get(schemes[cacheIdx]);
                 form = this.findForm(forms, op, affordance, schemes, cacheIdx);
             } else {
                 // new client
-                console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' has no client in cache (${cacheIdx})`);
+                console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' has no client in cache (${cacheIdx})`);
                 let srvIdx = schemes.findIndex(scheme => this.getServient().hasClientFor(scheme));
 
                 if (srvIdx === -1) throw new Error(`ConsumedThing '${this.title}' missing ClientFactory for '${schemes}'`);
 
                 client = this.getServient().getClientFor(schemes[srvIdx]);
-                console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' got new client for '${schemes[srvIdx]}'`);
+                console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' got new client for '${schemes[srvIdx]}'`);
 
                 this.ensureClientSecurity(client);
                 this.getClients().set(schemes[srvIdx], client);
@@ -221,13 +218,13 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' reading ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' reading ${form.href}`);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
 
                     client.readResource(form).then((content) => {
-                        resolve(new InteractionOutput(content, form, tp));
+                        resolve(new InteractionOutput(content,form,tp));
                     })
                         .catch(err => { reject(err); });
                 }
@@ -338,7 +335,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' invoking ${form.href}${parameter !== undefined ? " with '" + parameter + "'" : ""}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' invoking ${form.href}${parameter !== undefined ? " with '" + parameter + "'" : ""}`);
 
                     let input;
                     
@@ -384,7 +381,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' observing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' observing to ${form.href}`);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
@@ -395,7 +392,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                             try {
                                 listener(new InteractionOutput(content, form, tp));
                                 resolve();
-                            } catch (e) {
+                            } catch(e) {
                                 reject(new Error(`Received invalid content from Thing`));
                             }
                         },
@@ -423,7 +420,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' unobserveing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' unobserveing to ${form.href}`);
                     client.unlinkResource(form);
                     resolve();
                 }
@@ -443,7 +440,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' subscribing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' subscribing to ${form.href}`);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
@@ -482,7 +479,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' unsubscribing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' unsubscribing to ${form.href}`);
                     client.unlinkResource(form);
                     resolve();
                 }

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -293,14 +293,15 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else {
                     console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' writing ${form.href} with '${value}'`);
 
+                    let content = ContentManager.valueToContent(value, <any>tp, form.contentType);
+
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
                     
-                    let body = value instanceof ReadableStream ? ProtocolHelpers.toNodeStream(value).read() : value;
-                    client.writeResource(form, { body: body, type: form.contentType }).then(() => {
+                    client.writeResource(form, content).then(() => {
                             resolve();
-                        })
-                        .catch(err => { reject(err); });
+                    })
+                    .catch(err => { reject(err); });
                 }
             }
         });
@@ -340,10 +341,9 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                     console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' invoking ${form.href}${parameter !== undefined ? " with '" + parameter + "'" : ""}`);
 
                     let input;
-
+                    
                     if (parameter !== undefined) {
-                        let body = parameter instanceof ReadableStream ? ProtocolHelpers.toNodeStream(parameter).read() : parameter;
-                        input = { body: body, type: form.contentType };
+                        input = ContentManager.valueToContent(parameter, <any>ta.input, form.contentType);
                     }
 
                     // uriVariables ?

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -1,4 +1,3 @@
-import { DataSchemaValue, InteractionInput } from 'wot-typescript-definitions';
 /********************************************************************************
  * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
  * 
@@ -29,6 +28,7 @@ import { Subscribable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import UriTemplate = require('uritemplate');
 import { InteractionOutput } from "./interaction-output";
+import { InteractionInput } from 'wot-typescript-definitions';
 
 enum Affordance {
     PropertyAffordance,

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -329,8 +329,8 @@ class WoTClientTest {
         //an action
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("23");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("23");
                 return { type: "application/json", body: Readable.from(Buffer.from("42")) };
             }
         )

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -272,8 +272,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("23");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("23");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -290,8 +290,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("58");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("58");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -307,8 +307,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async(form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("66");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("66");
             }
         )
 

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -193,7 +193,7 @@ let myThingDesc = {
     events: {
         anEvent: {
             data: {
-                type: "string"
+                type:"string"
             },
             forms: [
                 { "href": "testdata://host/athing/events/anevent", "mediaType": "application/json" }
@@ -208,7 +208,7 @@ class WoTClientTest {
     static servient: Servient;
     static clientFactory: TrapClientFactory;
     static WoT: typeof WoT;
-    static WoTHelpers: Helpers;
+    static WoTHelpers : Helpers;
 
     static before() {
         this.servient = new Servient();
@@ -259,7 +259,7 @@ class WoTClientTest {
         expect(thing.getThingDescription()).to.have.property("properties");
         expect(thing.getThingDescription()).to.have.property("properties").to.have.property("aProperty");
 
-        const result: any = await thing.readAllProperties();
+        const result:any = await thing.readAllProperties();
         expect(result).not.to.be.null;
         expect(result).to.have.property("aProperty");
         expect(result).to.have.not.property("aPropertyToObserve");
@@ -306,7 +306,7 @@ class WoTClientTest {
     @test async "write multiple property new api"() {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
-            async (form: Form, content: Content) => {
+            async(form: Form, content: Content) => {
                 const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
                 expect(stream.value.toString()).to.equal("66");
             }
@@ -377,7 +377,7 @@ class WoTClientTest {
         const thing = await WoTClientTest.WoT.consume(td);
         expect(thing).to.have.property("title").that.equals("aThing");
         expect(thing).to.have.property("properties").that.has.property("aPropertyToObserve");
-        return new Promise((resolve) => {
+        return new Promise( (resolve)=> {
             thing.observeProperty("aPropertyToObserve",
                 async (data: any) => {
                     const value = await data.value();
@@ -404,7 +404,7 @@ class WoTClientTest {
                         done(new Error("property is not observable"))
                     }
                 )
-                    .catch(err => { done() });
+                .catch(err => { done() });
             })
             .catch(err => { done(err) });
     }

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -272,8 +272,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const buffer = await ProtocolHelpers.readStreamFully(Readable.from(content.body));
-                expect(buffer.toString()).to.equal("23");
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("23");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -290,7 +290,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                expect(content.body).to.equal(58);
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("58");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -306,8 +307,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const buffer = await ProtocolHelpers.readStreamFully(content.body);
-                expect(buffer.toString()).to.equal("66");
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("66");
             }
         )
 
@@ -320,7 +321,7 @@ class WoTClientTest {
         let valueMap: { [key: string]: any } = {};
         const stream = Readable.from(Buffer.from("66"));
 
-        valueMap["aProperty"] = stream;
+        valueMap["aProperty"] = ProtocolHelpers.toWoTStream(stream);
         return thing.writeMultipleProperties(valueMap);
     }
 
@@ -328,7 +329,8 @@ class WoTClientTest {
         //an action
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                expect(content.body.toString()).to.equal("23");
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("23");
                 return { type: "application/json", body: Readable.from(Buffer.from("42")) };
             }
         )


### PR DESCRIPTION
As documented [here](https://w3c.github.io/wot-scripting-api/#the-interactioninput-type), we now make use of the declared type `InteractionInput` (along with `InteractionOutput`) to pass data to `writeProperty` and `invokeAction` methods, inside consumed thing. Also tests were updated according the changes.