### PR TITLE
[core] TD validation in produce() method while exposing things

### DIFF
--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -14,7 +14,7 @@ import { DataSchemaValue, InteractionInput } from 'wot-typescript-definitions';
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
-import { ConsumedThing as IConsumedThing } from "wot-typescript-definitions";
+import {ConsumedThing as IConsumedThing} from "wot-typescript-definitions";
 
 import * as TD from "@node-wot/td-tools";
 
@@ -29,9 +29,6 @@ import { Subscribable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import UriTemplate = require('uritemplate');
 import { InteractionOutput } from "./interaction-output";
-import { Readable } from "stream";
-import ProtocolHelpers from "./protocol-helpers";
-import { ReadableStream } from 'web-streams-polyfill/ponyfill/es2018';
 
 enum Affordance {
     PropertyAffordance,
@@ -71,7 +68,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         // Deep clone the Thing Model 
         // without functions or methods
         let clonedModel = JSON.parse(JSON.stringify(thingModel))
-        Object.assign(this, clonedModel);
+        Object.assign(this,clonedModel);
         this.extendInteractions();
     }
 
@@ -80,7 +77,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     }
 
     public emitEvent(name: string, data: any): void {
-        console.warn("[core/consumed-thing]", "not implemented");
+        console.warn("[core/consumed-thing]","not implemented");
     }
 
     extendInteractions(): void {
@@ -135,7 +132,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     ensureClientSecurity(client: ProtocolClient) {
         // td-tools parser ensures this.security is an array
         if (this.security && this.securityDefinitions && Array.isArray(this.security) && this.security.length > 0) {
-            console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' setting credentials for ${client}`);
+            console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' setting credentials for ${client}`);
             let scs: Array<TD.SecurityScheme> = [];
             for (let s of this.security) {
                 let ws = this.securityDefinitions[s + ""]; // String vs. string (fix wot-typescript-definitions?)
@@ -159,14 +156,14 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
         if (options && options.formIndex) {
             // pick provided formIndex (if possible)
-            console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' asked to use formIndex '${options.formIndex}'`);
+            console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' asked to use formIndex '${options.formIndex}'`);
 
             if (options.formIndex >= 0 && options.formIndex < forms.length) {
                 form = forms[options.formIndex];
                 let scheme = Helpers.extractScheme(form.href);
 
                 if (this.getServient().hasClientFor(scheme)) {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' got client for '${scheme}'`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' got client for '${scheme}'`);
                     client = this.getServient().getClientFor(scheme);
 
                     if (!this.getClients().get(scheme)) {
@@ -186,18 +183,18 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
             if (cacheIdx !== -1) {
                 // from cache
-                console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`);
+                console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`);
                 client = this.getClients().get(schemes[cacheIdx]);
                 form = this.findForm(forms, op, affordance, schemes, cacheIdx);
             } else {
                 // new client
-                console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' has no client in cache (${cacheIdx})`);
+                console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' has no client in cache (${cacheIdx})`);
                 let srvIdx = schemes.findIndex(scheme => this.getServient().hasClientFor(scheme));
 
                 if (srvIdx === -1) throw new Error(`ConsumedThing '${this.title}' missing ClientFactory for '${schemes}'`);
 
                 client = this.getServient().getClientFor(schemes[srvIdx]);
-                console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' got new client for '${schemes[srvIdx]}'`);
+                console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' got new client for '${schemes[srvIdx]}'`);
 
                 this.ensureClientSecurity(client);
                 this.getClients().set(schemes[srvIdx], client);
@@ -221,13 +218,13 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' reading ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' reading ${form.href}`);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
 
                     client.readResource(form).then((content) => {
-                        resolve(new InteractionOutput(content, form, tp));
+                        resolve(new InteractionOutput(content,form,tp));
                     })
                         .catch(err => { reject(err); });
                 }
@@ -338,7 +335,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' invoking ${form.href}${parameter !== undefined ? " with '" + parameter + "'" : ""}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' invoking ${form.href}${parameter !== undefined ? " with '" + parameter + "'" : ""}`);
 
                     let input;
                     
@@ -384,7 +381,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' observing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' observing to ${form.href}`);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
@@ -395,7 +392,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                             try {
                                 listener(new InteractionOutput(content, form, tp));
                                 resolve();
-                            } catch (e) {
+                            } catch(e) {
                                 reject(new Error(`Received invalid content from Thing`));
                             }
                         },
@@ -423,7 +420,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' unobserveing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' unobserveing to ${form.href}`);
                     client.unlinkResource(form);
                     resolve();
                 }
@@ -443,7 +440,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' subscribing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' subscribing to ${form.href}`);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
@@ -482,7 +479,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else if (!form) {
                     reject(new Error(`ConsumedThing '${this.title}' did not get suitable form`));
                 } else {
-                    console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' unsubscribing to ${form.href}`);
+                    console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' unsubscribing to ${form.href}`);
                     client.unlinkResource(form);
                     resolve();
                 }

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -293,14 +293,15 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else {
                     console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' writing ${form.href} with '${value}'`);
 
+                    let content = ContentManager.valueToContent(value, <any>tp, form.contentType);
+
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
                     
-                    let body = value instanceof ReadableStream ? ProtocolHelpers.toNodeStream(value).read() : value;
-                    client.writeResource(form, { body: body, type: form.contentType }).then(() => {
+                    client.writeResource(form, content).then(() => {
                             resolve();
-                        })
-                        .catch(err => { reject(err); });
+                    })
+                    .catch(err => { reject(err); });
                 }
             }
         });
@@ -340,10 +341,9 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                     console.debug("[core/consumed-thing]", `ConsumedThing '${this.title}' invoking ${form.href}${parameter !== undefined ? " with '" + parameter + "'" : ""}`);
 
                     let input;
-
+                    
                     if (parameter !== undefined) {
-                        let body = parameter instanceof ReadableStream ? ProtocolHelpers.toNodeStream(parameter).read() : parameter;
-                        input = { body: body, type: form.contentType };
+                        input = ContentManager.valueToContent(parameter, <any>ta.input, form.contentType);
                     }
 
                     // uriVariables ?

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -76,7 +76,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         return JSON.parse(JSON.stringify(this));
     }
 
-    public emitEvent(name: string, data: any): void {
+    public emitEvent(name: string, data: InteractionInput): void {
         console.warn("[core/consumed-thing]","not implemented");
     }
 
@@ -206,7 +206,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     }
 
     readProperty(propertyName: string, options?: WoT.InteractionOptions): Promise<WoT.InteractionOutput> {
-        return new Promise<any>((resolve, reject) => {
+        return new Promise<WoT.InteractionOutput>((resolve, reject) => {
             // TODO pass expected form op to getClientFor()
             let tp: TD.ThingProperty = this.properties[propertyName];
             if (!tp) {
@@ -235,7 +235,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     _readProperties(propertyNames: string[]): Promise<WoT.PropertyReadMap> {
         return new Promise<WoT.PropertyReadMap>((resolve, reject) => {
             // collect all single promises into array
-            var promises: Promise<any>[] = [];
+            var promises: Promise<WoT.InteractionOutput>[] = [];
             for (let propertyName of propertyNames) {
                 promises.push(this.readProperty(propertyName));
             }
@@ -288,7 +288,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                 } else {
                     console.debug("[core/consumed-thing]",`ConsumedThing '${this.title}' writing ${form.href} with '${value}'`);
 
-                    let content = ContentManager.valueToContent(value, <any>tp, form.contentType);
+                    let content = ContentManager.valueToContent(value, tp, form.contentType);
 
                     // uriVariables ?
                     form = this.handleUriVariables(form, options);
@@ -304,10 +304,10 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     writeMultipleProperties(valueMap: WoT.PropertyWriteMap, options?: WoT.InteractionOptions): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             // collect all single promises into array
-            var promises: Promise<any>[] = [];
+            var promises: Promise<void>[] = [];
             for (let propertyName in valueMap) {
-                let oValueMap: { [key: string]: any; } = valueMap;
-                promises.push(this.writeProperty(propertyName, oValueMap[propertyName]));
+                const value = valueMap.get(propertyName);
+                promises.push(this.writeProperty(propertyName, value));
             }
             // wait for all promises to succeed and create response
             Promise.all(promises)
@@ -322,7 +322,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
 
     public invokeAction(actionName: string, parameter?: InteractionInput, options?: WoT.InteractionOptions): Promise<WoT.InteractionOutput> {
-        return new Promise<any>((resolve, reject) => {
+        return new Promise<WoT.InteractionOutput>((resolve, reject) => {
             let ta: TD.ThingAction = this.actions[actionName];
             if (!ta) {
                 reject(new Error(`ConsumedThing '${this.title}' does not have action ${actionName}`));
@@ -338,7 +338,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
                     let input;
                     
                     if (parameter !== undefined) {
-                        input = ContentManager.valueToContent(parameter, <any>ta.input, form.contentType);
+                        input = ContentManager.valueToContent(parameter, ta.input, form.contentType);
                     }
 
                     // uriVariables ?

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -1,4 +1,3 @@
-import { DataSchemaValue, InteractionInput } from 'wot-typescript-definitions';
 /********************************************************************************
  * Copyright (c) 2018 - 2019 Contributors to the Eclipse Foundation
  * 
@@ -29,6 +28,7 @@ import { Subscribable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import UriTemplate = require('uritemplate');
 import { InteractionOutput } from "./interaction-output";
+import { InteractionInput } from 'wot-typescript-definitions';
 
 enum Affordance {
     PropertyAffordance,

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -321,7 +321,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     }
 
 
-    public invokeAction(actionName: string, parameter?: InteractionInput, options?: WoT.InteractionOptions): Promise<InteractionOutput> {
+    public invokeAction(actionName: string, parameter?: InteractionInput, options?: WoT.InteractionOptions): Promise<WoT.InteractionOutput> {
         return new Promise<any>((resolve, reject) => {
             let ta: TD.ThingAction = this.actions[actionName];
             if (!ta) {

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -209,7 +209,16 @@ export default class Helpers {
    * Helper function to validate an ExposedThingInit
    */
   public static validateExposedThingInit(data : any) {
-    let exposeThingInitSchema = Helpers.validateThingDescription(JSON.parse(JSON.stringify(tdSchema)));
+    const td = JSON.parse(JSON.stringify(tdSchema));
+
+    if(data["@type"] !== undefined && data["@type"] == "tm:ThingModel") {
+      return {
+        valid: false,
+        errors: "ThingModel declaration is not supported"
+      };
+    }
+
+    let exposeThingInitSchema = Helpers.validateThingDescription(td);
     const validate = ajv.compile(exposeThingInitSchema);
     const isValid = validate(data);
     let errors = undefined;

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -204,18 +204,45 @@ export default class Helpers {
 
     if(tdSchemaCopy.definitions !== undefined){
         for (let prop in tdSchemaCopy.definitions) {  
-            this.createExposeThingInitSchema(tdSchemaCopy.definitions[prop])
+            tdSchemaCopy.definitions[prop] = this.createExposeThingInitSchema(tdSchemaCopy.definitions[prop])
         }
     }
 
     return tdSchemaCopy
   }
 
+  private static isThingModelThingDescription(data : any) : boolean {
+
+    for (let key in data) {
+        if(key == "tm:ref")
+            return true;
+    }
+
+    if(data.links !== undefined && Array.isArray(data.links)) {
+        let foundTmExtendsRel = false;
+        data.links.forEach((link : any) => {
+            if(link.rel !== undefined && link.rel == "tm:extends")
+                foundTmExtendsRel = true;
+        });
+        if(foundTmExtendsRel) return true;
+    }
+
+    if(data.properties !== undefined){
+        for (let prop in data.properties) {  
+            if(this.isThingModelThingDescription(data.properties[prop]))
+                return true;
+        }
+    }
+
+    return false;
+  }
+
   /**
    * Helper function to validate an ExposedThingInit
    */
   public static validateExposedThingInit(data : any) {
-    if(data["@type"] == "tm:ThingModel") {
+    if(data["@type"] == "tm:ThingModel"
+        || this.isThingModelThingDescription(data)) {
       return {
         valid: false,
         errors: "ThingModel declaration is not supported"

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -33,6 +33,11 @@ import Servient from "./servient";
 import * as TD from "@node-wot/td-tools";
 import { ContentSerdes } from "./content-serdes";
 import { ProtocolHelpers } from "./core";
+import Ajv from 'ajv';
+import TDSchema from "wot-typescript-definitions/schema/td-json-schema-validation.json";
+
+const tdSchema = TDSchema;
+const ajv = new Ajv({strict:false});
 
 export default class Helpers {
 
@@ -172,5 +177,48 @@ export default class Helpers {
       console.error("[core/helpers]", "parseInteractionOutput low-level stream not implemented");
     }
     return value;
+  }
+
+  /**
+   * Helper function to remove reserved keywords in required property of TD JSON Schema
+   */
+  static validateThingDescription(td: any) {
+    if(td.required !== undefined) {
+        let reservedKeywords: Array<string> = [ 
+            "title", "@context", "instance", "forms", "security", "href", "securityDefinitions"
+        ]
+        if (Array.isArray(td.required)) {
+            let reqProps: Array<string> =td.required;
+            td.required = reqProps.filter(n => !reservedKeywords.includes(n))
+        } else if (typeof td.required === "string") {
+            if(reservedKeywords.indexOf(td.required) !== -1)
+                delete td.required
+        }
+    }
+
+    if(td.definitions !== undefined){
+        for (let prop in td.definitions) {  
+            this.validateThingDescription(td.definitions[prop])
+        }
+    }
+
+    return td
+  }
+
+  /**
+   * Helper function to validate an ExposedThingInit
+   */
+  public static validateExposedThingInit(data : any) {
+    let exposeThingInitSchema = Helpers.validateThingDescription(JSON.parse(JSON.stringify(tdSchema)));
+    const validate = ajv.compile(exposeThingInitSchema);
+    const isValid = validate(data);
+    let errors = undefined;
+    if(!isValid) {
+      errors = validate.errors.map(o => o.message).join('\n');
+    }
+    return {
+      valid: isValid,
+      errors: errors
+    };
   }
 }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -43,7 +43,7 @@ const ajv = new Ajv({strict:false});
  
 export default class Helpers {
 
-  static tsSchemaValidator = ajv.compile(Helpers.validateThingDescription(tdSchema));
+  static tsSchemaValidator = ajv.compile(Helpers.createExposeThingInitSchema(tdSchema));
 
   private srv: Servient;
 
@@ -186,27 +186,29 @@ export default class Helpers {
   /**
    * Helper function to remove reserved keywords in required property of TD JSON Schema
    */
-  static validateThingDescription(td: any) {
-    if(td.required !== undefined) {
+  static createExposeThingInitSchema(tdSchema: unknown) {
+    let tdSchemaCopy = JSON.parse(JSON.stringify(tdSchema));
+
+    if(tdSchemaCopy.required !== undefined) {
         let reservedKeywords: Array<string> = [ 
             "title", "@context", "instance", "forms", "security", "href", "securityDefinitions"
         ]
-        if (Array.isArray(td.required)) {
-            let reqProps: Array<string> =td.required;
-            td.required = reqProps.filter(n => !reservedKeywords.includes(n))
-        } else if (typeof td.required === "string") {
-            if(reservedKeywords.indexOf(td.required) !== -1)
-                delete td.required
+        if (Array.isArray(tdSchemaCopy.required)) {
+            let reqProps: Array<string> = tdSchemaCopy.required;
+            tdSchemaCopy.required = reqProps.filter(n => !reservedKeywords.includes(n))
+        } else if (typeof tdSchemaCopy.required === "string") {
+            if(reservedKeywords.indexOf(tdSchemaCopy.required) !== -1)
+                delete tdSchemaCopy.required
         }
     }
 
-    if(td.definitions !== undefined){
-        for (let prop in td.definitions) {  
-            this.validateThingDescription(td.definitions[prop])
+    if(tdSchemaCopy.definitions !== undefined){
+        for (let prop in tdSchemaCopy.definitions) {  
+            this.createExposeThingInitSchema(tdSchemaCopy.definitions[prop])
         }
     }
 
-    return td
+    return tdSchemaCopy
   }
 
   /**

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -39,7 +39,11 @@ import TDSchema from "wot-typescript-definitions/schema/td-json-schema-validatio
 const tdSchema = TDSchema;
 const ajv = new Ajv({strict:false});
 
+
+ 
 export default class Helpers {
+
+  static tsSchemaValidator = ajv.compile(Helpers.validateThingDescription(tdSchema));
 
   private srv: Servient;
 
@@ -209,21 +213,16 @@ export default class Helpers {
    * Helper function to validate an ExposedThingInit
    */
   public static validateExposedThingInit(data : any) {
-    const td = JSON.parse(JSON.stringify(tdSchema));
-
-    if(data["@type"] !== undefined && data["@type"] == "tm:ThingModel") {
+    if(data["@type"] == "tm:ThingModel") {
       return {
         valid: false,
         errors: "ThingModel declaration is not supported"
       };
     }
-
-    let exposeThingInitSchema = Helpers.validateThingDescription(td);
-    const validate = ajv.compile(exposeThingInitSchema);
-    const isValid = validate(data);
+    const isValid = Helpers.tsSchemaValidator(data);
     let errors = undefined;
     if(!isValid) {
-      errors = validate.errors.map(o => o.message).join('\n');
+      errors = Helpers.tsSchemaValidator.errors.map(o => o.message).join('\n');
     }
     return {
       valid: isValid,

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -20,9 +20,9 @@ import * as TD from "@node-wot/td-tools";
 import Servient from "./servient";
 import ExposedThing from "./exposed-thing";
 import ConsumedThing from "./consumed-thing";
-import Ajv from 'ajv';
+import Helpers from "./helpers";
 
-const ajv = new Ajv({strict:false, allErrors: true});
+const tdSchema = TDSchema;
 
 export default class WoTImpl {
     private srv: Servient;
@@ -74,28 +74,7 @@ export default class WoTImpl {
         }
     }
 
-    validateThingDescription(td: any) {
-        if(td.required !== undefined) {
-            let reservedKeywords: Array<string> = [ 
-                "title", "@context", "instance", "forms", "security", "href"
-            ]
-            if (Array.isArray(td.required)) {
-                let reqProps: Array<string> =td.required;
-                td.required = reqProps.filter(n => !reservedKeywords.includes(n))
-            } else if (typeof td.required === "string") {
-                if(reservedKeywords.indexOf(td.required) !== -1)
-                    delete td.required
-            }
-        }
-
-        if(td.properties !== undefined){
-            for (let prop in td.properties) {  
-                this.validateThingDescription(td.properties[prop])
-            }
-        }
-
-        return td
-    }
+    
 
     /**
      * create a new Thing
@@ -109,17 +88,13 @@ export default class WoTImpl {
 
                 // FIXME should be constrained version that omits instance-specific parts (but keeps "id")
                 let template = td;
-
-                let tdSchema = TDSchema;
-                let exposeThingInitSchema = this.validateThingDescription(tdSchema);
-
-                const validate = ajv.compile(exposeThingInitSchema)
-
-                if(!validate(template)) {
-                    throw new Error("Thing Description JSON schema validation failed: " + JSON.stringify(validate.errors));
+                
+                let validated = Helpers.validateExposedThingInit(template);
+                
+                if(!validated.valid) {
+                    throw new Error("Thing Description JSON schema validation failed:\n" + validated.errors);
                 }
 
-                this.validateThingDescription(template);
                 this.addDefaultLanguage(template);
 
                 newThing =  new ExposedThing(this.srv,td);

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -74,6 +74,29 @@ export default class WoTImpl {
         }
     }
 
+    validateThingDescription(td: any) {
+        if(td.required !== undefined) {
+            let reservedKeywords: Array<string> = [ 
+                "title", "@context", "instance", "forms", "security", "href"
+            ]
+            if (Array.isArray(td.required)) {
+                let reqProps: Array<string> =td.required;
+                td.required = reqProps.filter(n => !reservedKeywords.includes(n))
+            } else if (typeof td.required === "string") {
+                if(reservedKeywords.indexOf(td.required) !== -1)
+                    delete td.required
+            }
+        }
+
+        if(td.properties !== undefined){
+            for (let prop in td.properties) {  
+                this.validateThingDescription(td.properties[prop])
+            }
+        }
+
+        return td
+    }
+
     /**
      * create a new Thing
      *
@@ -86,7 +109,10 @@ export default class WoTImpl {
 
                 // FIXME should be constrained version that omits instance-specific parts (but keeps "id")
                 let template = td;
+
+                this.validateThingDescription(template);
                 this.addDefaultLanguage(template);
+
                 newThing =  new ExposedThing(this.srv,td);
 
                 console.debug("[core/servient]",`WoTImpl producing new ExposedThing '${newThing.title}'`);

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -329,8 +329,8 @@ class WoTClientTest {
         //an action
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("23");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("23");
                 return { type: "application/json", body: Readable.from(Buffer.from("42")) };
             }
         )

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -272,8 +272,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("23");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("23");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -290,8 +290,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("58");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("58");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -307,8 +307,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async(form: Form, content: Content) => {
-                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
-                expect(stream.value.toString()).to.equal("66");
+                const valueData = await ProtocolHelpers.readStreamFully(content.body);
+                expect(valueData.toString()).to.equal("66");
             }
         )
 

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -193,7 +193,7 @@ let myThingDesc = {
     events: {
         anEvent: {
             data: {
-                type: "string"
+                type:"string"
             },
             forms: [
                 { "href": "testdata://host/athing/events/anevent", "mediaType": "application/json" }
@@ -208,7 +208,7 @@ class WoTClientTest {
     static servient: Servient;
     static clientFactory: TrapClientFactory;
     static WoT: typeof WoT;
-    static WoTHelpers: Helpers;
+    static WoTHelpers : Helpers;
 
     static before() {
         this.servient = new Servient();
@@ -259,7 +259,7 @@ class WoTClientTest {
         expect(thing.getThingDescription()).to.have.property("properties");
         expect(thing.getThingDescription()).to.have.property("properties").to.have.property("aProperty");
 
-        const result: any = await thing.readAllProperties();
+        const result:any = await thing.readAllProperties();
         expect(result).not.to.be.null;
         expect(result).to.have.property("aProperty");
         expect(result).to.have.not.property("aPropertyToObserve");
@@ -306,7 +306,7 @@ class WoTClientTest {
     @test async "write multiple property new api"() {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
-            async (form: Form, content: Content) => {
+            async(form: Form, content: Content) => {
                 const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
                 expect(stream.value.toString()).to.equal("66");
             }
@@ -377,7 +377,7 @@ class WoTClientTest {
         const thing = await WoTClientTest.WoT.consume(td);
         expect(thing).to.have.property("title").that.equals("aThing");
         expect(thing).to.have.property("properties").that.has.property("aPropertyToObserve");
-        return new Promise((resolve) => {
+        return new Promise( (resolve)=> {
             thing.observeProperty("aPropertyToObserve",
                 async (data: any) => {
                     const value = await data.value();
@@ -404,7 +404,7 @@ class WoTClientTest {
                         done(new Error("property is not observable"))
                     }
                 )
-                    .catch(err => { done() });
+                .catch(err => { done() });
             })
             .catch(err => { done(err) });
     }

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -272,8 +272,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const buffer = await ProtocolHelpers.readStreamFully(Readable.from(content.body));
-                expect(buffer.toString()).to.equal("23");
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("23");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -290,7 +290,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                expect(content.body).to.equal(58);
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("58");
             }
         )
         const td = await WoTClientTest.WoTHelpers.fetch("td://foo");
@@ -306,8 +307,8 @@ class WoTClientTest {
         //verify the value transmitted
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                const buffer = await ProtocolHelpers.readStreamFully(content.body);
-                expect(buffer.toString()).to.equal("66");
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("66");
             }
         )
 
@@ -320,7 +321,7 @@ class WoTClientTest {
         let valueMap: { [key: string]: any } = {};
         const stream = Readable.from(Buffer.from("66"));
 
-        valueMap["aProperty"] = stream;
+        valueMap["aProperty"] = ProtocolHelpers.toWoTStream(stream);
         return thing.writeMultipleProperties(valueMap);
     }
 
@@ -328,7 +329,8 @@ class WoTClientTest {
         //an action
         WoTClientTest.clientFactory.setTrap(
             async (form: Form, content: Content) => {
-                expect(content.body.toString()).to.equal("23");
+                const stream = await ProtocolHelpers.toWoTStream(content.body).getReader().read();
+                expect(stream.value.toString()).to.equal("23");
                 return { type: "application/json", body: Readable.from(Buffer.from("42")) };
             }
         )

--- a/packages/core/test/HelpersTest.ts
+++ b/packages/core/test/HelpersTest.ts
@@ -48,4 +48,21 @@ class HelperTest {
         let scheme = Helpers.extractScheme("coap+ws://blablupp.de")
         expect(scheme).to.eq("coap+ws")
     }
+
+    @test "should correctly validate schema"() {
+        let thing = {
+            title: "thingTest",
+            properties: {
+                myProp: { 
+                    type: "number"
+                }
+            }
+        };
+
+        let validated = Helpers.validateExposedThingInit(thing);
+
+        expect(thing).to.exist;
+        expect(validated.valid).to.be.true;
+        expect(validated.errors).to.be.undefined;
+    }
 }

--- a/packages/core/test/HelpersTest.ts
+++ b/packages/core/test/HelpersTest.ts
@@ -65,4 +65,24 @@ class HelperTest {
         expect(validated.valid).to.be.true;
         expect(validated.errors).to.be.undefined;
     }
+
+    @test "should reject ThingModel schema on validation"() {
+        let thing = {
+            title: "thingTest",
+            links: [{
+                "rel": "tm:extend"
+            }],
+            properties: {
+                myProp: { 
+                    "tm:ref": "http://example.com/thingTest.tm.jsonld#/properties/myProp",
+                    type: "number"
+                }
+            }
+        };
+
+        let validated = Helpers.validateExposedThingInit(thing);
+
+        expect(thing).to.exist;
+        expect(validated.valid).to.be.false;
+    }
 }

--- a/packages/core/test/InteractionOutputTest.ts
+++ b/packages/core/test/InteractionOutputTest.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 
 import { suite, test } from "mocha-typescript";
-import * as promised from "chai-as-promised";
+import promised from "chai-as-promised";
 import { expect } from "chai";
 import {use} from 'chai';
 import {Readable} from 'stream';

--- a/packages/core/test/ServerTest.ts
+++ b/packages/core/test/ServerTest.ts
@@ -88,6 +88,28 @@ class WoTServerTest {
         expect(thing).to.have.property("properties");
         expect(thing).to.have.property("properties").to.have.property("myProp");
     }
+
+    @test async "validate thing description"() {
+        let thing = await WoTServerTest.WoT.produce({
+            title: "myFragmentThing",
+            support: "none",
+            properties: {
+                myProp: { 
+                    type: "object",
+                    properties: {
+                        myProp2: { }
+                    },
+                    required: [ "myProp2", "forms", "href" ]
+                }
+            },
+            required: "href"
+        });
+
+        expect(thing).to.exist;
+        expect(thing).not.to.have.property("required")
+        expect(thing).to.have.property("properties").to.have.property("myProp")
+            .to.have.property("required").that.eql(["myProp2"])
+    }
     //TODO: Review server side tests since ExposedThing does not implement ConsumedThing anymore
     /*
     @test async "should be able to add a Thing based on WoT.ThingDescription"() {

--- a/packages/core/test/ServerTest.ts
+++ b/packages/core/test/ServerTest.ts
@@ -71,9 +71,14 @@ class WoTServerTest {
         let thing = await WoTServerTest.WoT.produce({
             title: "myFragmentThing",
             support: "none",
+            securityDefinitions: {"psk_sc":{"scheme": "psk"}},
             "test:custom": "test",
             properties: {
-                myProp: { }
+                myProp: { 
+                    "forms": [{
+                        "href": "href"
+                    }]
+                }
             }
         });
 
@@ -94,9 +99,13 @@ class WoTServerTest {
         let thing = await WoTServerTest.WoT.produce({
             title: "myFragmentThing",
             support: "none",
+            securityDefinitions: {"psk_sc":{"scheme": "psk"}},
             properties: {
                 myProp: {
                     type: "object",
+                    "forms": [{
+                        "href": "href"
+                    }],
                     properties: {
                         myProp2: { }
                     },
@@ -237,9 +246,13 @@ class WoTServerTest {
     @test async "should be able to add a thing with spaces in title and property "() {
         let thing = await WoTServerTest.WoT.produce({
             title: "The Machine",
+            securityDefinitions: {"psk_sc":{"scheme": "psk"}},
             properties: {
                 "my number": {
-                    type: "number"
+                    type: "number",
+                    "forms": [{
+                        "href": "href"
+                    }]
                 }
             }
         });

--- a/packages/core/test/ServerTest.ts
+++ b/packages/core/test/ServerTest.ts
@@ -71,13 +71,10 @@ class WoTServerTest {
         let thing = await WoTServerTest.WoT.produce({
             title: "myFragmentThing",
             support: "none",
-            securityDefinitions: {"psk_sc":{"scheme": "psk"}},
             "test:custom": "test",
             properties: {
                 myProp: { 
-                    "forms": [{
-                        "href": "href"
-                    }]
+                    
                 }
             }
         });
@@ -95,31 +92,6 @@ class WoTServerTest {
         expect(thing).to.have.property("properties").to.have.property("myProp");
     }
 
-    @test async "validate thing description"() {
-        let thing = await WoTServerTest.WoT.produce({
-            title: "myFragmentThing",
-            support: "none",
-            securityDefinitions: {"psk_sc":{"scheme": "psk"}},
-            properties: {
-                myProp: {
-                    type: "object",
-                    "forms": [{
-                        "href": "href"
-                    }],
-                    properties: {
-                        myProp2: { }
-                    },
-                    required: [ "myProp2", "forms", "href" ]
-                }
-            },
-            required: "href"
-        });
-
-        expect(thing).to.exist;
-        expect(thing).not.to.have.property("required")
-        expect(thing).to.have.property("properties").to.have.property("myProp")
-            .to.have.property("required").that.eql(["myProp2"])
-    }
     //TODO: Review server side tests since ExposedThing does not implement ConsumedThing anymore
     /*
     @test async "should be able to add a Thing based on WoT.ThingDescription"() {
@@ -246,13 +218,9 @@ class WoTServerTest {
     @test async "should be able to add a thing with spaces in title and property "() {
         let thing = await WoTServerTest.WoT.produce({
             title: "The Machine",
-            securityDefinitions: {"psk_sc":{"scheme": "psk"}},
             properties: {
                 "my number": {
                     type: "number",
-                    "forms": [{
-                        "href": "href"
-                    }]
                 }
             }
         });

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,9 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "dist"
+		"outDir": "dist",
+		"resolveJsonModule": true,
+		"esModuleInterop": true
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
Now `WoT.produce()` validates the TD according [this specification](https://w3c.github.io/wot-scripting-api/#validating-an-exposedthinginit). Related test was also added for completeness.